### PR TITLE
XRT-3522: Fix reading uninitialised memory

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -733,20 +733,22 @@ static int MQTTAsync_unpersistInflightMessages(Clients* c)
 	{
 		while (rc == 0 && i < nkeys)
 		{
-			if (strncmp(msgkeys[i], PERSISTENCE_PUBLISH_SENT, strlen(PERSISTENCE_PUBLISH_SENT)) == 0 ||
-				strncmp(msgkeys[i], PERSISTENCE_V5_PUBLISH_SENT, strlen(PERSISTENCE_V5_PUBLISH_SENT)) == 0 ||
-				strncmp(msgkeys[i], PERSISTENCE_PUBREL, strlen(PERSISTENCE_PUBREL)) == 0 ||
-				strncmp(msgkeys[i], PERSISTENCE_V5_PUBREL, strlen(PERSISTENCE_V5_PUBREL)) == 0 ||
-				strncmp(msgkeys[i], PERSISTENCE_PUBLISH_RECEIVED, strlen(PERSISTENCE_PUBLISH_RECEIVED)) == 0 ||
-				strncmp(msgkeys[i], PERSISTENCE_V5_PUBLISH_RECEIVED, strlen(PERSISTENCE_V5_PUBLISH_RECEIVED)) == 0)
+			if (msgkeys[i] != NULL)
 			{
-				if ((rc = c->persistence->premove(c->phandle, msgkeys[i])) == 0)
-					messages_deleted++;
-				else
-					Log(LOG_ERROR, 0, "Error %d removing inflight message from persistence", rc);
-			}
-			if (msgkeys[i])
+				if (strncmp(msgkeys[i], PERSISTENCE_PUBLISH_SENT, strlen(PERSISTENCE_PUBLISH_SENT)) == 0 ||
+					strncmp(msgkeys[i], PERSISTENCE_V5_PUBLISH_SENT, strlen(PERSISTENCE_V5_PUBLISH_SENT)) == 0 ||
+					strncmp(msgkeys[i], PERSISTENCE_PUBREL, strlen(PERSISTENCE_PUBREL)) == 0 ||
+					strncmp(msgkeys[i], PERSISTENCE_V5_PUBREL, strlen(PERSISTENCE_V5_PUBREL)) == 0 ||
+					strncmp(msgkeys[i], PERSISTENCE_PUBLISH_RECEIVED, strlen(PERSISTENCE_PUBLISH_RECEIVED)) == 0 ||
+					strncmp(msgkeys[i], PERSISTENCE_V5_PUBLISH_RECEIVED, strlen(PERSISTENCE_V5_PUBLISH_RECEIVED)) == 0)
+				{
+					if ((rc = c->persistence->premove(c->phandle, msgkeys[i])) == 0)
+						messages_deleted++;
+					else
+						Log(LOG_ERROR, 0, "Error %d removing inflight message from persistence", rc);
+				}
 				free(msgkeys[i]);
+			}
 			i++;
 		}
 		if (msgkeys != NULL)

--- a/src/MQTTPersistenceDefault.c
+++ b/src/MQTTPersistenceDefault.c
@@ -779,7 +779,7 @@ int keysUnix(char *dirname, char ***keys, int *nkeys)
 	char **fkeys = NULL;
 	int nfkeys = 0;
 	char *ptraux;
-	int i;
+	int i = 0;
 	DIR *dp = NULL;
 	struct dirent *dir_entry;
 	struct stat stat_info;
@@ -818,7 +818,7 @@ int keysUnix(char *dirname, char ***keys, int *nkeys)
 
 	if (nfkeys != 0)
 	{
-		if ((fkeys = (char **)malloc(nfkeys * sizeof(char *))) == NULL)
+		if ((fkeys = (char **)calloc(nfkeys, sizeof(char *))) == NULL)
 		{
 			rc = PAHO_MEMORY_ERROR;
 			goto exit;
@@ -879,7 +879,7 @@ int keysUnix(char *dirname, char ***keys, int *nkeys)
 		}
 	}
 
-	*nkeys = nfkeys;
+	*nkeys = i;
 	*keys = fkeys;
 	/* the caller must free keys */
 


### PR DESCRIPTION
- `MQTTAsync_unpersistInflightMessages` does not check if the entry is `NULL` leading to crash. 

Added a null check to prevent this.

- `keysUnix` does two passes over the directory and files can be deleted between passes (even during passes) leading to `keysUnix` setting `*nkeys` to the number of files it found in the first pass, not the number of filenames it copied on the second pass. 
 
Changed `*nkeys` to return the number of filenames it copied over instead of the number of array entries. Also changed `malloc` to `calloc` so it's more defensive but maybe not necessary? 